### PR TITLE
make compatible with guard-bundler

### DIFF
--- a/lib/guard/ctags-bundler.rb
+++ b/lib/guard/ctags-bundler.rb
@@ -33,7 +33,7 @@ module Guard
     end
 
     def generate_bundler_tags
-      runtime = Bundler::Runtime.new Dir.pwd, Bundler.definition
+      runtime = ::Bundler::Runtime.new Dir.pwd, ::Bundler.definition
       paths = runtime.specs.map(&:full_gem_path).join(' ')
       system("find #{paths.strip} -type f -name \\*.rb | ctags -f gems.tags -L -")
     end


### PR DESCRIPTION
Without this, guard fails:

regenerating bundler tags...
ERROR: Guard::CtagsBundler failed to achieve its <run_on_change>, exception was:
NameError: uninitialized constant Guard::Bundler::Runtime
/home/jmou/.rvm/gems/ruby-1.9.2-p290/gems/guard-ctags-bundler-0.0.3/lib/guard/ctags-bundler.rb:36:in `generate_bundler_tags'
/home/jmou/.rvm/gems/ruby-1.9.2-p290/gems/guard-ctags-bundler-0.0.3/lib/guard/ctags-bundler.rb:20:in`run_on_change'
