### PR TITLE
Run at start to tag changes made when Guard not running

### DIFF
--- a/lib/guard/ctags-bundler.rb
+++ b/lib/guard/ctags-bundler.rb
@@ -12,6 +12,7 @@ module Guard
 
     def start
       UI.info 'Guard::CtagsBundler is running!'
+      run_on_change(['Gemfile.lock', '.'])
     end
 
     def run_on_change(paths)


### PR DESCRIPTION
Small change to run tagging at startup, so that changes made when Guard's not running are tagged, and so that tags are present as soon as enabled in Guardfile.
