### PR TITLE
Implement run_on_changes for guard 1.1

### DIFF
--- a/lib/guard/ctags-bundler.rb
+++ b/lib/guard/ctags-bundler.rb
@@ -14,7 +14,7 @@ module Guard
       UI.info 'Guard::CtagsBundler is running!'
     end
 
-    def run_on_change(paths)
+    def run_on_changes(paths)
       if paths.include?('Gemfile.lock')
         UI.info "regenerating bundler tags..."
         generate_bundler_tags


### PR DESCRIPTION
Guard 1.1 deprecates `run_on_change` and splits it out into different methods as part of integrating the Listen gem. The generic change method was changed to `run_on_changes` if you do not care about the kind of change, which I believe is the case for this.

The full deprecation message is below:

DEPRECATION: Starting with Guard v1.1 the use of the 'run_on_change' method in the 'Guard::CtagsBundler' guard is deprecated.
Please consider replacing that method-call with 'run_on_changes' if the type of change
is not important for your usecase or using either 'run_on_modifications' or 'run_on_additions'
based on the type of the changes you want to handle.
For more information on how to update existing guards, please head over to:
https://github.com/guard/guard/wiki/Upgrade-guide-for-existing-guards-to-Guard-v1.1
