### PR TITLE
incompatibility with guard-bundler

### DIFF
--- a/lib/guard/ctags-bundler/ctags_generator.rb
+++ b/lib/guard/ctags-bundler/ctags_generator.rb
@@ -10,8 +10,8 @@ module Guard
       end
 
       def generate_bundler_tags
-        definition = Bundler::Definition.build("Gemfile", "Gemfile.lock", nil)
-        runtime = Bundler::Runtime.new(Dir.pwd, definition)
+        definition = ::Bundler::Definition.build("Gemfile", "Gemfile.lock", nil)
+        runtime = ::Bundler::Runtime.new(Dir.pwd, definition)
         paths = runtime.requested_specs.map(&:full_gem_path)
         generate_tags(paths, "gems.tags")
       end


### PR DESCRIPTION
I was receiving the error:

```
Bundle already up-to-date
Guard::CtagsBundler is running!
ERROR: Guard::CtagsBundler failed to achieve its <start>, exception was:
NameError: uninitialized constant Guard::Bundler::Definition
/Users/glanotte/.rvm/gems/ruby-1.9.3-p194@sos/gems/guard-ctags-bundler-0.1.3/lib/guard/ctags-bundler/ctags_generator.rb:13:in `generate_bundler_tags'
/Users/glanotte/.rvm/gems/ruby-1.9.3-p194@sos/gems/guard-ctags-bundler-0.1.3/lib/guard/ctags-bundler.rb:17:in `start'
```

I changed the references to bundler to ::Bundler to get it to force a top-level lookup. This resolved my error.

I believe this is because I am using guard-bundler as well, so the `Guard::Bundler` module did exist but not the `Guard::Bundler::Definition`
