### PR TITLE
Quick custom_path option

### DIFF
--- a/lib/guard/ctags-bundler/ctags_generator.rb
+++ b/lib/guard/ctags-bundler/ctags_generator.rb
@@ -6,14 +6,14 @@ module Guard
       end
 
       def generate_project_tags
-        generate_tags(@opts[:src_path] || ".", "tags")
+        generate_tags(@opts[:src_path] || ".", custom_path_for("tags"))
       end
 
       def generate_bundler_tags
         definition = Bundler::Definition.build("Gemfile", "Gemfile.lock", nil)
         runtime = Bundler::Runtime.new(Dir.pwd, definition)
         paths = runtime.requested_specs.map(&:full_gem_path)
-        generate_tags(paths, "gems.tags")
+        generate_tags(paths, custom_path_for("gems.tags") )
       end
 
       private
@@ -22,12 +22,21 @@ module Guard
         if path.instance_of?(Array)
           path = path.join(' ').strip
         end
-
+        system("mkdir  ./#{@opts[:custom_path]}") if @opts[:custom_path]
         cmd = "find #{path} -type f -name \\*.rb | ctags -f #{tag_file} -L -"
         cmd << " -e" if @opts[:emacs]
         system(cmd)
-        system("cat tags gems.tags > TAGS") if @opts[:emacs]
+        system("cat #{custom_path_for("tags")} #{custom_path_for("gems.tags")} > TAGS") if @opts[:emacs]
       end
+
+      def custom_path_for(file)
+        if @opts[:custom_path]
+          return "./#{@opts[:custom_path]}/#{file}"
+        else
+          return file
+        end
+      end
+
     end
   end
 end

--- a/test/ctags-bundler/ctags_generator_test.rb
+++ b/test/ctags-bundler/ctags_generator_test.rb
@@ -32,6 +32,15 @@ class CtagsGeneratorTest < MiniTest::Unit::TestCase
     refute_match("method_of_class_3", result)
   end
 
+  def test_generate_project_tags_for_custom_path
+    generator(custom_path: "custom").generate_project_tags
+    result = File.read(custom_path_file)
+    assert_match("method_of_class_1", result)
+    assert_match("method_of_class_2", result)
+    assert_match("method_of_class_3", result)
+    refute_match("Rake", result)
+  end
+
   private
 
   def generator(opts = {})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,8 +13,16 @@ def test_gems_tags_file
   File.join(test_project_path, "gems.tags")
 end
 
+def custom_path_file
+  File.join(test_project_path, "custom", "tags")
+end
+
 def clean_tags
-  [test_tags_file, test_gems_tags_file].each do |file|
+  [test_tags_file, test_gems_tags_file, custom_path_file].each do |file|
     File.delete(file) if File.exists?(file)
+  end
+
+  if File.exists?(File.join(test_project_path, 'custom'))
+    system("rmdir #{File.join(test_project_path, 'custom')}")
   end
 end


### PR DESCRIPTION
Hi,

I was wondering if you could consider this custom_path method for the ctags generation under a custom_path.

Some days ago I started using ctags+ack but my results also show me the ctags file. So I did a quick hack that I present you to save the ctags under a custom path, so that my ViM is happy with them, but don't pollute my ack results using ignore dir.

It was hacked fast, so probably some feedback could help to get this to a release quality. 
