### PR TITLE
Fix for running outside bundler

### DIFF
--- a/lib/guard/ctags-bundler/ctags_generator.rb
+++ b/lib/guard/ctags-bundler/ctags_generator.rb
@@ -10,6 +10,7 @@ module Guard
       end
 
       def generate_bundler_tags
+        ::Bundler.configure # in case we're not running guard from inside Bundler
         definition = ::Bundler::Definition.build("Gemfile", "Gemfile.lock", nil)
         runtime = ::Bundler::Runtime.new(Dir.pwd, definition)
         paths = runtime.requested_specs.map(&:full_gem_path)


### PR DESCRIPTION
since ctags (and other guard use cases) are very workflow-specific,
it's reasonable to run guard outside of Bundler so that you don't
force everybody to ex. generate ctags if they don't use them. However,
previously, bundler won't be configured at the time ctags-bundler
is run.

This commit runs a quick ::Bundler.configure, just to make sure we're
GTG for all use cases.
