### PR TITLE
add configuration options to customize output file names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Please, read [Guard usage doc](https://github.com/guard/guard#readme)
 :stdlib => true, # run ctags for core and stdlib, generating stdlib.tags (default false)
 :binary => 'ctags-exuberant' # name of the ctags binary (default ctags)
 :arguments => '-R --languages=ruby --fields=+l' # change the arguments passed to ctags (default '-R --languages=ruby')
+:stdlib_file => "stdlib.tags" # name of tags file for stdlib references (default stdlib.tags)
+:bundler_tags_file => "gems.tags" # name of tags file for bundler gems references (default gems.tags)
+:project_file => "tags" # name of tags file for project references (default tags)
 ```
 
 For a typical Rails application, `Guardfile` can look like this (default):

--- a/lib/guard/ctags-bundler/ctags_generator.rb
+++ b/lib/guard/ctags-bundler/ctags_generator.rb
@@ -10,7 +10,7 @@ module Guard
       end
 
       def generate_project_tags
-        generate_tags(@opts[:src_path] || ".", custom_path_for("tags"))
+        generate_tags(@opts[:src_path] || ".", custom_path_for(@opts.fetch(:project_file, "tags")))
       end
 
       def generate_bundler_tags
@@ -32,11 +32,11 @@ module Guard
         CMD
         paths = `ruby -e "#{cmd}"`
 
-        generate_tags(paths.strip, custom_path_for("gems.tags"))
+        generate_tags(paths.strip, custom_path_for(@opts.fetch(:bundler_tags_file, "gems.tags")))
       end
 
       def generate_stdlib_tags
-        generate_tags(stdlib_path, custom_path_for("stdlib.tags"))
+        generate_tags(stdlib_path, custom_path_for(@opts.fetch(:stdlib_file, "stdlib.tags")))
       end
 
       private

--- a/test/ctags-bundler/ctags_generator_test.rb
+++ b/test/ctags-bundler/ctags_generator_test.rb
@@ -37,6 +37,16 @@ class CtagsGeneratorTest < MiniTest::Unit::TestCase
     refute_match("method_of_class_3", result)
   end
 
+  def test_generate_bundler_tags_for_gems_file
+    generator(:bundler_tags_file => 'override.tags').generate_bundler_tags
+    assert File.exists?(test_override_tags_file)
+    result = File.read(test_override_tags_file)
+    assert_match(/\bGuardfile\b/, result)
+    refute_match("method_of_class_1", result)
+    refute_match("method_of_class_2", result)
+    refute_match("method_of_class_3", result)
+  end
+
   def test_generate_stdlib_tags
     # rubinius standard library is packaged in gems
     if defined?(RUBY_ENGINE) && RUBY_ENGINE != "rbx"
@@ -52,9 +62,33 @@ class CtagsGeneratorTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_generate_stdlib_tags_for_stdlib_file
+    # rubinius standard library is packaged in gems
+    if defined?(RUBY_ENGINE) && RUBY_ENGINE != "rbx"
+      generator(:stdlib_file => "override.tags").generate_stdlib_tags
+      assert File.exists?(test_override_tags_file)
+      result = File.read(test_override_tags_file)
+      assert_match("DateTime", result)
+      assert_match("YAML", result)
+      refute_match(/\bGuardfile\b/, result)
+      refute_match("method_of_class_1", result)
+      refute_match("method_of_class_2", result)
+      refute_match("method_of_class_3", result)
+    end
+  end
+
   def test_generate_project_tags_for_custom_path
     generator(:custom_path => "custom").generate_project_tags
     result = File.read(custom_path_file)
+    assert_match("method_of_class_1", result)
+    assert_match("method_of_class_2", result)
+    assert_match("method_of_class_3", result)
+    refute_match("Rake", result)
+  end
+
+  def test_generate_project_tags_for_project_file
+    generator(:project_file => "override.tags").generate_project_tags
+    result = File.read(test_override_tags_file)
     assert_match("method_of_class_1", result)
     assert_match("method_of_class_2", result)
     assert_match("method_of_class_3", result)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,8 +22,12 @@ def test_stdlib_tags_file
   File.join(test_project_path, "stdlib.tags")
 end
 
+def test_override_tags_file
+  File.join(test_project_path, "override.tags")
+end
+
 def clean_tags
-  [test_tags_file, test_gems_tags_file, test_stdlib_tags_file, custom_path_file].each do |file|
+  [test_tags_file, test_gems_tags_file, test_stdlib_tags_file, custom_path_file, test_override_tags_file].each do |file|
     File.delete(file) if File.exists?(file)
   end
 


### PR DESCRIPTION
this is intended to help out sublimetext users so they can customize the output files to match the expected default filenames used by the sublime-ctags plugin.
