### PR TITLE
Support more than just ctags and exuberant-ctags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Please, read [Guard usage doc](https://github.com/guard/guard#readme)
 :emacs => false, # run ctags in emacs mode and merge tags and gems.tags into TAGS file
 :stdlib => true, # run ctags for core and stdlib, generating stdlib.tags (default false)
 :binary => 'ctags-exuberant' # name of the ctags binary (default ctags)
-:arguments => '-R --languages=ruby --fields=+l' # change the arguments passed to ctags (default '-R --languages=ruby')
+:arguments => '-R --languages=ruby --fields=+l' # change the arguments passed to ctags (default '-R --languages=ruby --exclude=".#*"')
 :stdlib_file => "stdlib.tags" # name of tags file for stdlib references (default stdlib.tags)
 :bundler_tags_file => "gems.tags" # name of tags file for bundler gems references (default gems.tags)
 :project_file => "tags" # name of tags file for project references (default tags)

--- a/lib/guard/ctags-bundler/ctags_generator.rb
+++ b/lib/guard/ctags-bundler/ctags_generator.rb
@@ -48,7 +48,7 @@ module Guard
           path = path.join(' ').strip
         end
         system("mkdir -p ./#{@opts[:custom_path]}") if @opts[:custom_path]
-        cmd = "#{@opts[:binary] || 'ctags'} -f #{tag_file} #{@opts[:arguments] || '-R --languages=ruby'} --exclude='.#*'"
+        cmd = "#{@opts[:binary] || 'ctags'} -f #{tag_file} #{@opts[:arguments] || '-R --languages=ruby --exclude=".#*"'}"
         cmd << " -e" if @opts[:emacs]
         cmd << " #{path}"
         system(cmd)


### PR DESCRIPTION
Some tag generators, like hasktags for haskell, don't support the --exclude option. I moved the `--exclude` option passed to ctags into the default options so that it can be reset using `:arguments`
